### PR TITLE
Use a method compatible with mongoid-observers to determinine the version of mongoid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.4.5 (Next)
 ------------
 
+* [#123](https://github.com/aq1018/mongoid-history/pull/123): Use a method compatible with mongoid-observers to determinine the version of Mongoid - [@zeitnot](https://github.com/zeitnot).
 * Your contribution here.
 
 0.4.4 (7/29/2014)

--- a/lib/mongoid-history.rb
+++ b/lib/mongoid-history.rb
@@ -1,4 +1,5 @@
 require 'easy_diff'
+require 'versionomy'
 
 require 'mongoid/history'
 require 'mongoid/history/version'

--- a/lib/mongoid/history/mongoid.rb
+++ b/lib/mongoid/history/mongoid.rb
@@ -1,7 +1,7 @@
 module Mongoid
   module History
     def self.mongoid3?
-      ::Mongoid.const_defined? :Observer # deprecated in Mongoid 4.x
+      Versionomy.parse(::Mongoid::VERSION).major == 3
     end
   end
 end

--- a/mongoid-history.gemspec
+++ b/mongoid-history.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'easy_diff'
   s.add_runtime_dependency 'mongoid', '>= 3.0'
   s.add_runtime_dependency 'activesupport'
+  s.add_runtime_dependency 'versionomy'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.1'


### PR DESCRIPTION
Fixes #121, see #123.