### PR TITLE
Support multiple levels of embedded polimorphic documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------
 
 * [#127](https://github.com/aq1018/mongoid-history/pull/127) - Fix gem naming per [rubygems](http://guides.rubygems.org/name-your-gem/) specs, now you can `require 'mongoid/history'` - [@nofxx](https://github.com/nofxx).
+* [#129](https://github.com/aq1018/mongoid-history/pull/129) - Support multiple levels of embedded polimorphic documents - [@BrunoChauvet](https://github.com/BrunoChauvet).
 * Your contribution here.
 
 0.4.4 (7/29/2014)

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -138,13 +138,20 @@ module Mongoid
 
         def related_scope
           scope = history_trackable_options[:scope]
-          scope = _parent.collection_name.to_s.singularize.to_sym if scope.is_a?(Array)
 
-          if Mongoid::History.mongoid3?
-            scope = metadata.inverse_class_name.tableize.singularize.to_sym if metadata.present? && scope == metadata.as
+          # Use top level document if its name is specified in the scope
+          root_document_name = traverse_association_chain.first['name'].singularize.underscore.gsub('/', '_').to_sym
+          if scope.is_a?(Array) && scope.include?(root_document_name)
+            scope = root_document_name
           else
-            scope = relation_metadata.inverse_class_name.tableize.singularize.to_sym if relation_metadata.present? && scope == relation_metadata.as
+            scope = _parent.collection_name.to_s.singularize.to_sym if scope.is_a?(Array)
+            if Mongoid::History.mongoid3?
+              scope = metadata.inverse_class_name.tableize.singularize.to_sym if metadata.present? && scope == metadata.as
+            else
+              scope = relation_metadata.inverse_class_name.tableize.singularize.to_sym if relation_metadata.present? && scope == relation_metadata.as
+            end
           end
+
           scope
         end
 

--- a/spec/integration/nested_embedded_polymorphic_documents_spec.rb
+++ b/spec/integration/nested_embedded_polymorphic_documents_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+
+describe Mongoid::History::Tracker do
+  before :all do
+    class Modelone
+      include Mongoid::Document
+      include Mongoid::History::Trackable
+
+      field :name, type: String
+      belongs_to :user
+      embeds_one :embedded_one,  as: :embedable
+
+      track_history on: :all,
+                    modifier_field: :modifier,
+                    version_field: :version,
+                    track_create: true,
+                    track_update: true,
+                    track_destroy: true
+    end
+
+    class Modeltwo
+      include Mongoid::Document
+      include Mongoid::History::Trackable
+
+      field :name, type: String
+      belongs_to :user
+      embeds_one :embedded_one,  as: :embedable
+
+      track_history on: :all,
+                    modifier_field: :modifier,
+                    version_field: :version,
+                    track_create: true,
+                    track_update: true,
+                    track_destroy: true
+    end
+
+    class EmbeddedOne
+      include Mongoid::Document
+      include Mongoid::History::Trackable
+
+      field :name
+      embeds_many :embedded_twos, store_as: :ems
+      embedded_in :embedable, polymorphic: true
+
+      track_history on: :all,
+                    modifier_field: :modifier,
+                    version_field: :version,
+                    track_create: true,
+                    track_update: true,
+                    track_destroy: true,
+                    scope: [:modelone, :modeltwo]
+    end
+
+    class EmbeddedTwo
+      include Mongoid::Document
+      include Mongoid::History::Trackable
+
+      field :name
+      embedded_in :embedded_one
+
+      track_history on: :all,
+                    modifier_field: :modifier,
+                    version_field: :version,
+                    track_create: true,
+                    track_update: true,
+                    track_destroy: true,
+                    scope: [:modelone, :modeltwo]
+    end
+
+    class User
+      include Mongoid::Document
+      has_many :modelones
+      has_many :modeltwos
+    end
+  end
+
+  it 'tracks history for nested embedded documents with polymorphic relations' do
+    user = User.new
+    user.save!
+
+    modelone = user.modelones.build(name: 'modelone')
+    modelone.save!
+    modelone.build_embedded_one(name: 'modelone_embedded_one').save!
+    expect(modelone.history_tracks.count).to eq(2)
+    expect(modelone.embedded_one.history_tracks.count).to eq(1)
+
+    modelone.reload
+    modelone.embedded_one.update_attribute(:name, 'modelone_embedded_one!')
+    expect(modelone.history_tracks.count).to eq(3)
+    expect(modelone.embedded_one.history_tracks.count).to eq(2)
+    expect(modelone.history_tracks.last.action).to eq('update')
+
+    modelone.build_embedded_one(name: 'Lorem ipsum').save!
+    expect(modelone.history_tracks.count).to eq(4)
+    expect(modelone.embedded_one.history_tracks.count).to eq(1)
+    expect(modelone.history_tracks.last.action).to eq('create')
+    expect(modelone.history_tracks.last.association_chain.last['name']).to eq('embedded_one')
+
+    embedded_one1 = modelone.embedded_one.embedded_twos.create(name: 'modelone_embedded_one_1')
+    expect(modelone.history_tracks.count).to eq(5)
+    expect(modelone.embedded_one.history_tracks.count).to eq(2)
+    expect(embedded_one1.history_tracks.count).to eq(1)
+
+    modeltwo = user.modeltwos.build(name: 'modeltwo')
+    modeltwo.save!
+    modeltwo.build_embedded_one(name: 'modeltwo_embedded_one').save!
+    expect(modeltwo.history_tracks.count).to eq(2)
+    expect(modeltwo.embedded_one.history_tracks.count).to eq(1)
+
+    modeltwo.reload
+    modeltwo.embedded_one.update_attribute(:name, 'modeltwo_embedded_one!')
+    expect(modeltwo.history_tracks.count).to eq(3)
+    expect(modeltwo.embedded_one.history_tracks.count).to eq(2)
+    expect(modeltwo.history_tracks.last.action).to eq('update')
+
+    modeltwo.build_embedded_one(name: 'Lorem ipsum').save!
+    expect(modeltwo.history_tracks.count).to eq(4)
+    expect(modeltwo.embedded_one.history_tracks.count).to eq(1)
+    expect(modeltwo.history_tracks.last.action).to eq('create')
+    expect(modeltwo.history_tracks.last.association_chain.last['name']).to eq('embedded_one')
+
+    embedded_one2 = modeltwo.embedded_one.embedded_twos.create(name: 'modeltwo_embedded_one_1')
+    expect(modeltwo.history_tracks.count).to eq(5)
+    expect(modeltwo.embedded_one.history_tracks.count).to eq(2)
+    expect(embedded_one2.history_tracks.count).to eq(1)
+  end
+end


### PR DESCRIPTION
My model contains a polymorphic embedded document containing a collection of embedded documents.
I could not get the history tracker on the top level document to track the modification under the collection of nested embedded documents.
The pull request fixes this issue.

```ruby
class Modelone
      include Mongoid::Document
      include Mongoid::History::Trackable

      field :name, type: String
      belongs_to :user
      embeds_one :embone,  as: :embedable

      track_history on: :all, ...
    end
```

```ruby
class Modeltwo
      include Mongoid::Document
      include Mongoid::History::Trackable

      field :name, type: String
      belongs_to :user
      embeds_one :embone,  as: :embedable

      track_history on: :all, ...
    end
```

```ruby
class Embone
      include Mongoid::Document
      include Mongoid::History::Trackable

      field :name
      embeds_many :embtwos, store_as: :ems
      embedded_in :embedable, polymorphic: true

      track_history on: :all, scope: [:modelone, :modeltwo]
    end
```

```ruby
class Embtwo
      include Mongoid::Document
      include Mongoid::History::Trackable

      field :name
      embedded_in :embone

      track_history on: :all, scope: [:modelone, :modeltwo]
    end
```