### PR TITLE
Undo method that does not save changes to object;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.4.5 (Next)
 ------------
 
+* [#131](https://github.com/aq1018/mongoid-history/pull/131) - Add `undo` method, that helps to get specific version of an object without saving changes - [@alexkravets](https://github.com/alexkravets).
 * [#127](https://github.com/aq1018/mongoid-history/pull/127) - Fix gem naming per [rubygems](http://guides.rubygems.org/name-your-gem/) specs, now you can `require 'mongoid/history'` - [@nofxx](https://github.com/nofxx).
 * Your contribution here.
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ track.undo! user # comment title should be "Test"
 
 track.redo! user # comment title should be "Test 2"
 
+# undo comment to version 1 without save
+comment.undo nil, from: 1, to: comment.version
+
 # undo last change
 comment.undo! user
 

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -74,7 +74,7 @@ module Mongoid
         #  undo :from => 1, :to => 5
         #  undo 4
         #  undo :last => 10
-        def undo!(modifier = nil, options_or_version = nil)
+        def undo(modifier = nil, options_or_version = nil)
           versions = get_versions_criteria(options_or_version).to_a
           versions.sort! { |v1, v2| v2.version <=> v1.version }
 
@@ -82,11 +82,18 @@ module Mongoid
             undo_attr = v.undo_attr(modifier)
             if Mongoid::History.mongoid3? # update_attributes! not bypassing rails 3 protected attributes
               assign_attributes(undo_attr, without_protection: true)
-              save!
             else # assign_attributes with 'without_protection' option does not work with rails 4/mongoid 4
-              update_attributes!(undo_attr)
+              self.attributes = undo_attr
             end
           end
+        end
+
+        #  undo! :from => 1, :to => 5
+        #  undo! 4
+        #  undo! :last => 10
+        def undo!(modifier = nil, options_or_version = nil)
+          undo(modifier, options_or_version)
+          save!
         end
 
         def redo!(modifier = nil, options_or_version = nil)

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -627,52 +627,54 @@ describe Mongoid::History do
       end
 
       describe 'undo' do
-        [nil, :reload].each do |method|
-          context "#{method || 'instance'}" do
-            it 'should recognize :from, :to options' do
-              comment.undo! user, from: 4, to: 2
-              comment.send(method) if method
-              expect(comment.title).to eq('test')
-            end
+        { 'undo'  => [nil], 'undo!' => [nil, :reload] }.each do |test_method, methods|
+          methods.each do |method|
+            context "#{method || 'instance'}" do
+              it 'recognizes :from, :to options' do
+                comment.send test_method, user, from: 4, to: 2
+                comment.send(method) if method
+                expect(comment.title).to eq('test')
+              end
 
-            it 'should recognize parameter as version number' do
-              comment.undo! user, 3
-              comment.send(method) if method
-              expect(comment.title).to eq('Test2')
-            end
+              it 'recognizes parameter as version number' do
+                comment.send test_method, user, 3
+                comment.send(method) if method
+                expect(comment.title).to eq('Test2')
+              end
 
-            it 'should undo last version when no parameter is specified' do
-              comment.undo! user
-              comment.send(method) if method
-              expect(comment.title).to eq('Test3')
-            end
+              it 'should undo last version when no parameter is specified' do
+                comment.send test_method, user
+                comment.send(method) if method
+                expect(comment.title).to eq('Test3')
+              end
 
-            it 'should recognize :last options' do
-              comment.undo! user, last: 2
-              comment.send(method) if method
-              expect(comment.title).to eq('Test2')
-            end
+              it 'recognizes :last options' do
+                comment.send test_method, user, last: 2
+                comment.send(method) if method
+                expect(comment.title).to eq('Test2')
+              end
 
-            if Mongoid::History.mongoid3?
-              context 'protected attributes' do
-                before :each do
-                  Comment.attr_accessible(nil)
-                end
+              if Mongoid::History.mongoid3?
+                context 'protected attributes' do
+                  before :each do
+                    Comment.attr_accessible(nil)
+                  end
 
-                after :each do
-                  Comment.attr_protected(nil)
-                end
+                  after :each do
+                    Comment.attr_protected(nil)
+                  end
 
-                it 'should undo last version when no parameter is specified on protected attributes' do
-                  comment.undo! user
-                  comment.send(method) if method
-                  expect(comment.title).to eq('Test3')
-                end
+                  it 'should undo last version when no parameter is specified on protected attributes' do
+                    comment.send test_method, user
+                    comment.send(method) if method
+                    expect(comment.title).to eq('Test3')
+                  end
 
-                it 'should recognize :last options on model with protected attributes' do
-                  comment.undo! user, last: 2
-                  comment.send(method) if method
-                  expect(comment.title).to eq('Test2')
+                  it 'recognizes :last options on model with protected attributes' do
+                    comment.send test_method, user, last: 2
+                    comment.send(method) if method
+                    expect(comment.title).to eq('Test2')
+                  end
                 end
               end
             end


### PR DESCRIPTION
This make it possible to get specific version of an object: ```object.undo(nill, from: <version>, to: object.version)```