### PR TITLE
Use a method compatible with mongoid-observers to determinine the version of mongoid (without versionomy dependency)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.4.5 (Next)
 ------------
 
+* [#123](https://github.com/aq1018/mongoid-history/pull/123): Use a method compatible with mongoid-observers to determinine the version of Mongoid - [@zeitnot](https://github.com/zeitnot).
 * Your contribution here.
 
 0.4.4 (7/29/2014)

--- a/lib/mongoid/history/mongoid.rb
+++ b/lib/mongoid/history/mongoid.rb
@@ -1,7 +1,7 @@
 module Mongoid
   module History
     def self.mongoid3?
-      ::Mongoid.const_defined? :Observer # deprecated in Mongoid 4.x
+      Mongoid::VERSION =~ /^3\./
     end
   end
 end


### PR DESCRIPTION
Same as dblock's PR but without the added dependency.