### PR TITLE
Add dynamic attributes tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Next
 ----
 
+* [#133](https://github.com/aq1018/mongoid-history/pull/133) - Add dynamic attributes tracking (Mongoid::Attributes::Dynamic) - [@minisai](https://github.com/minisai).
 * [#124](https://github.com/aq1018/mongoid-history/pull/124) - You can require both `mongoid-history` and `mongoid/history` - [@dblock](https://github.com/dblock).
 * Your contribution here.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ class Post
   embeds_many     :comments
 
   # telling Mongoid::History how you want to track changes
+  # dynamic fields will be tracked automatically (for MongoId 4.0+ you should include Mongoid::Attributes::Dynamic to your model)
   track_history   :on => [:title, :body],       # track title and body fields only, default is :all
                   :modifier_field => :modifier, # adds "belongs_to :modifier" to track who made the change, default is :modifier
                   :modifier_field_inverse_of => :nil, # adds an ":inverse_of" option to the "belongs_to :modifier" relation, default is not set

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -54,6 +54,10 @@ module Mongoid
           Mongoid::History.enabled? && Thread.current[track_history_flag] != false
         end
 
+        def dynamic_enabled?
+          Mongoid::History.mongoid3? || (self < Mongoid::Attributes::Dynamic).present?
+        end
+
         def disable_tracking(&_block)
           Thread.current[track_history_flag] = false
           yield
@@ -293,7 +297,16 @@ module Mongoid
         #
         # @return [ Boolean ] whether or not the field is tracked for the given action
         def tracked_field?(field, action = :update)
-          tracked_fields_for_action(action).include? database_field_name(field)
+          dynamic_field?(field) || tracked_fields_for_action(action).include?(database_field_name(field))
+        end
+
+        # Checks if field is dynamic.
+        #
+        # @param [ String | Symbol ] field The name of the dynamic field
+        #
+        # @return [ Boolean ] whether or not the field is dynamic
+        def dynamic_field?(field)
+          dynamic_enabled? && !fields.keys.include?(database_field_name(field))
         end
 
         # Retrieves the list of tracked fields for a given action.

--- a/spec/unit/trackable_spec.rb
+++ b/spec/unit/trackable_spec.rb
@@ -6,6 +6,12 @@ class MyModel
   field :foo
 end
 
+class MyDynamicModel
+  include Mongoid::Document
+  include Mongoid::History::Trackable
+  include Mongoid::Attributes::Dynamic unless Mongoid::History.mongoid3?
+end
+
 class HistoryTracker
   include Mongoid::History::Tracker
 end
@@ -94,6 +100,40 @@ describe Mongoid::History::Trackable do
       end
       it 'should allow field aliases' do
         expect(MyModel.tracked_field?(:id, :destroy)).to be true
+      end
+
+      context 'when model is dynamic' do
+        it 'should allow dynamic fields tracking' do
+          MyDynamicModel.track_history
+          expect(MyDynamicModel.tracked_field?(:dynamic_field, :destroy)).to be true
+        end
+      end
+
+      unless Mongoid::History.mongoid3?
+        context 'when model is not dynamic' do
+          it 'should not allow dynamic fields tracking' do
+            MyModel.track_history
+            expect(MyModel.tracked_field?(:dynamic_field, :destroy)).to be false
+          end
+        end
+      end
+    end
+
+    context '#dynamic_field?' do
+      context 'when model is dynamic' do
+        it 'should return true' do
+          MyDynamicModel.track_history
+          expect(MyDynamicModel.dynamic_field?(:dynamic_field)).to be true
+        end
+      end
+
+      unless Mongoid::History.mongoid3?
+        context 'when model is not dynamic' do
+          it 'should return false' do
+            MyModel.track_history
+            expect(MyModel.dynamic_field?(:dynamic_field)).to be false
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Currently mongoid-history considers only changes to attributes, which are described in model as "fields". There were no way to track changes to dynamic attributes, which could be set if you include Mongoid::Attributes::Dynamic to your model. I think that gem should support dynamic attributes tracking. 

Please let me know if you have any remarks about implementation.