### PR TITLE
Skip track without modifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 Gemfile.lock
 
 .rvmrc
+.idea
 
 # rcov generated
 coverage

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ class Post
                   :modifier_field => :modifier, # adds "belongs_to :modifier" to track who made the change, default is :modifier
                   :modifier_field_inverse_of => :nil, # adds an ":inverse_of" option to the "belongs_to :modifier" relation, default is not set
                   :version_field => :version,   # adds "field :version, :type => Integer" to track current version, default is :version
+                  :track_without_modifier => false # do not save tracks when modifier is not set
                   :track_create   =>  false,    # track document creation, default is false
                   :track_update   =>  true,     # track document updates, default is true
                   :track_destroy  =>  false     # track document destruction, default is false
@@ -261,6 +262,27 @@ Or perhaps you are namespacing to a module:
 
 ```ruby
 Mongoid::History.modifier_class_name = 'CMS::Author'
+```
+
+**Skipping tracks without modifier set**
+
+If you don't want to save tracks when modifier for a model is not set, you can set `track_without_modifier` option to `false` either globally:
+
+```ruby
+  Mongoid::History.track_without_modifier = false
+```
+
+or per-model:
+
+```ruby
+class Post
+  include Mongoid::Document
+  include Mongoid::History::Trackable
+  field           :title
+  field           :body
+
+  track_history   :on => [:title, :body], :track_without_modifier => false
+end
 ```
 
 **Using an alternate changes method**

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ class Post
                   :modifier_field => :modifier, # adds "belongs_to :modifier" to track who made the change, default is :modifier
                   :modifier_field_inverse_of => :nil, # adds an ":inverse_of" option to the "belongs_to :modifier" relation, default is not set
                   :version_field => :version,   # adds "field :version, :type => Integer" to track current version, default is :version
-                  :track_without_modifier => false # do not save tracks when modifier is not set
+                  :track_without_modifier => true # save tracks when modifier is not set
                   :track_create   =>  false,    # track document creation, default is false
                   :track_update   =>  true,     # track document updates, default is true
                   :track_destroy  =>  false     # track document destruction, default is false

--- a/lib/mongoid/history.rb
+++ b/lib/mongoid/history.rb
@@ -13,6 +13,7 @@ module Mongoid
     mattr_accessor :trackable_class_options
     mattr_accessor :modifier_class_name
     mattr_accessor :current_user_method
+    mattr_accessor :track_without_modifier
 
     def self.tracker_class
       @tracker_class ||= tracker_class_name.to_s.classify.constantize
@@ -34,3 +35,5 @@ end
 Mongoid::History.modifier_class_name = 'User'
 Mongoid::History.trackable_class_options = {}
 Mongoid::History.current_user_method ||= :current_user
+Mongoid::History.track_without_modifier = true
+

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -13,6 +13,7 @@ module Mongoid
             version_field: :version,
             changes_method: :changes,
             scope: scope_name,
+            track_without_modifier: Mongoid::History.track_without_modifier,
             track_create: false,
             track_update: true,
             track_destroy: false
@@ -276,7 +277,9 @@ module Mongoid
         protected
 
         def track_history_for_action?(action)
-          track_history? && !(action.to_sym == :update && modified_attributes_for_update.blank?)
+          track_history? &&
+            !(action.to_sym == :update && modified_attributes_for_update.blank?) &&
+            (history_trackable_options[:track_without_modifier] || !!send(history_trackable_options[:modifier_field]))
         end
 
         def track_history_for_action(action)

--- a/lib/mongoid/history/tracker.rb
+++ b/lib/mongoid/history/tracker.rb
@@ -14,7 +14,7 @@ module Mongoid
         field :version,                 type: Integer
         field :action,                  type: String
         field :scope,                   type: String
-        belongs_to :modifier,                class_name: Mongoid::History.modifier_class_name
+        belongs_to :modifier,           class_name: Mongoid::History.modifier_class_name
 
         index(scope: 1)
         index(association_chain: 1)


### PR DESCRIPTION
Hi,

This update introduces the possibility to not save tracks when modifier of the model being changed is not set. This comes handy in case the models get updated in many places on backend, but we only need to track changes made by users.