### PR TITLE
Specify non-database fields to track for changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------
 
 * [#133](https://github.com/aq1018/mongoid-history/pull/133) - Add dynamic attributes tracking (Mongoid::Attributes::Dynamic) - [@minisai](https://github.com/minisai).
+* [#142](https://github.com/aq1018/mongoid-history/pull/142) - Allow non-database fields to be specified in conjunction with a custom changes method - [@kayakyakr](https://github.com/kayakyakr).
 * Your contribution here.
 
 0.4.7 (4/6/2015)

--- a/README.md
+++ b/README.md
@@ -270,7 +270,30 @@ and nested attributes, you may wish to write your own changes method that includ
 
 Mongoid::History provides an option named `:changes_method` which allows you to do this.  It defaults to `:changes`, which is the standard changes method.
 
+Note: Specify additional fields that are provided with a custom `changes_method` with the `:on` option.. To specify current fields and additional fields, use `fields.keys + [:custom]`
+
 Example:
+
+```ruby
+class Foo
+  include Mongoid::Document
+  include Mongoid::History::Trackable
+
+  attr_accessor :ip
+
+  track_history on: [:ip], changes_method: :my_changes
+
+  def my_changes
+    unless ip.nil?
+      changes.merge(ip: [nil, ip])
+    else
+      changes
+    end
+  end
+end
+```
+
+Example with embedded & nested attributes:
 
 ```ruby
 class Foo
@@ -284,11 +307,11 @@ class Foo
 
   # use changes_with_baz to include baz's changes in this document's
   # history.
-  track_history     :changes_method => :changes_with_baz
+  track_history   on: fields.keys + [:baz], changes_method: :changes_with_baz
 
   def changes_with_baz
     if baz.changed?
-      changes.merge( :baz => summarized_changes(baz) )
+      changes.merge(baz: summarized_changes(baz))
     else
       changes
     end

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -325,10 +325,10 @@ module Mongoid
         #
         # @return [ Array < String > ] the base list of tracked database field names
         def tracked_fields
-          @tracked_fields ||= fields.keys.select do |field|
+          @tracked_fields ||= begin
             h = history_trackable_options
-            (h[:on] == :all || h[:on].include?(field)) && !h[:except].include?(field)
-          end - reserved_tracked_fields
+            (h[:on] == :all ? fields.keys : h[:on]) - h[:except] - reserved_tracked_fields
+          end
         end
 
         # Retrieves the memoized list of reserved tracked fields, which are only included for certain actions.

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -901,5 +901,28 @@ describe Mongoid::History do
         end
       end
     end
+
+    describe 'overriden changes_method with additional fields' do
+      before :each do
+        class OverriddenChangesMethod
+          include Mongoid::Document
+          include Mongoid::History::Trackable
+
+          track_history on: [:foo], changes_method: :my_changes
+
+          def my_changes
+            { foo: %w(bar baz) }
+          end
+        end
+      end
+
+      it 'should add foo to the changes history' do
+        o = OverriddenChangesMethod.create
+        o.save
+        track = o.history_tracks.last
+        expect(track.modified).to eq('foo' => 'baz')
+        expect(track.original).to eq('foo' => 'bar')
+      end
+    end
   end
 end

--- a/spec/unit/trackable_spec.rb
+++ b/spec/unit/trackable_spec.rb
@@ -117,6 +117,16 @@ describe Mongoid::History::Trackable do
           end
         end
       end
+
+      it 'allows a non-database field to be specified' do
+        class MyNonDatabaseModel
+          include Mongoid::Document
+          include Mongoid::History::Trackable
+          track_history on: ['baz']
+        end
+
+        expect(MyNonDatabaseModel.tracked_field?(:baz)).to be true
+      end
     end
 
     context '#dynamic_field?' do


### PR DESCRIPTION
Adding ability to specify non-database fields to track for changes. This combines with changes method override to allow you to track arbitrary values, if needed