### PR TITLE
Rebase of PR #151 (multi-tracker)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,7 +27,7 @@ Metrics/LineLength:
 # Offense count: 7
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 32
+  Max: 33
 
 # Offense count: 2
 # Configuration parameters: CountComments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ------------
 
 * Your contribution here.
+* [#151](https://github.com/aq1018/mongoid-history/pull/151): Added ability to customize tracker class for each trackable; multiple trackers across the app are now possible - [@JagdeepSingh](https://github.com/JagdeepSingh).
+* [#151](https://github.com/aq1018/mongoid-history/pull/151): Added automatic support for `request_store` gem as drop-in replacement for `Thread.current` - [@JagdeepSingh](https://github.com/JagdeepSingh).
 
 * [#150](https://github.com/aq1018/mongoid-history/pull/150): Added support for keeping embedded objects audit history in parent itself - [@JagdeepSingh](https://github.com/JagdeepSingh).
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,5 @@ when /3/
 else
   gem 'mongoid', version
 end
+
+gem 'request_store', ENV['REQUEST_STORE_VERSION'] if ENV['REQUEST_STORE_VERSION']

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ class HistoryTracker
 end
 ```
 
-**Set tracker class name**
+**Set default tracker class name (Optional)**
 
-Manually set the tracker class name to make sure your tracker can be found and loaded properly. You can skip this step if you manually require your tracker before using any trackables.
-
-The following example sets the tracker class name using a Rails initializer.
+Mongoid::History will use the first loaded class to include Mongoid::History::Tracker as the
+default history tracker. If you are using multiple Tracker classes and would like to set
+a global default you may do so in a Rails initializer:
 
 ```ruby
-# config/initializers/mongoid-history.rb
+# config/initializers/mongoid_history.rb
 # initializer for mongoid-history
 # assuming HistoryTracker is your tracker class
 Mongoid::History.tracker_class_name = :history_tracker
@@ -396,6 +396,15 @@ end
 ```
 
 For more examples, check out [spec/integration/integration_spec.rb](https://github.com/aq1018/mongoid-history/blob/master/spec/integration/integration_spec.rb).
+
+
+**Thread Safety**
+
+Mongoid::History stores the tracking enable/disable flag in `Thread.current`.
+If the [RequestStore](https://github.com/steveklabnik/request_store) gem is installed, Mongoid::History
+will automatically store variables in the `RequestStore.store` instead. RequestStore is recommended
+for threaded web servers like Thin or Puma.
+
 
 Contributing to mongoid-history
 -------------------------------

--- a/lib/mongoid/history.rb
+++ b/lib/mongoid/history.rb
@@ -9,24 +9,26 @@ module Mongoid
   module History
     GLOBAL_TRACK_HISTORY_FLAG = 'mongoid_history_trackable_enabled'
 
-    mattr_accessor :tracker_class_name
-    mattr_accessor :trackable_class_options
-    mattr_accessor :modifier_class_name
-    mattr_accessor :current_user_method
+    class << self
+      attr_accessor :tracker_class_name
+      attr_accessor :trackable_class_options
+      attr_accessor :modifier_class_name
+      attr_accessor :current_user_method
 
-    def self.tracker_class
-      @tracker_class ||= tracker_class_name.to_s.classify.constantize
-    end
+      def disable(&_block)
+        store[GLOBAL_TRACK_HISTORY_FLAG] = false
+        yield
+      ensure
+        store[GLOBAL_TRACK_HISTORY_FLAG] = true
+      end
 
-    def self.disable(&_block)
-      Thread.current[GLOBAL_TRACK_HISTORY_FLAG] = false
-      yield
-    ensure
-      Thread.current[GLOBAL_TRACK_HISTORY_FLAG] = true
-    end
+      def enabled?
+        store[GLOBAL_TRACK_HISTORY_FLAG] != false
+      end
 
-    def self.enabled?
-      Thread.current[GLOBAL_TRACK_HISTORY_FLAG] != false
+      def store
+        defined?(RequestStore) ? RequestStore.store : Thread.current
+      end
     end
   end
 end

--- a/lib/mongoid/history/options.rb
+++ b/lib/mongoid/history/options.rb
@@ -14,6 +14,7 @@ module Mongoid
       def default_options
         { on: :all,
           except: [:created_at, :updated_at],
+          tracker_class_name: nil,
           modifier_field: :modifier,
           version_field: :version,
           changes_method: :changes,

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -29,7 +29,7 @@ module Mongoid
         end
 
         def track_history?
-          Mongoid::History.enabled? && Thread.current[track_history_flag] != false
+          Mongoid::History.enabled? && Mongoid::History.store[track_history_flag] != false
         end
 
         def dynamic_enabled?
@@ -37,20 +37,25 @@ module Mongoid
         end
 
         def disable_tracking(&_block)
-          Thread.current[track_history_flag] = false
+          Mongoid::History.store[track_history_flag] = false
           yield
         ensure
-          Thread.current[track_history_flag] = true
+          Mongoid::History.store[track_history_flag] = true
         end
 
         def track_history_flag
           "mongoid_history_#{name.underscore}_trackable_enabled".to_sym
         end
+
+        def tracker_class
+          klass = history_trackable_options[:tracker_class_name] || Mongoid::History.tracker_class_name
+          klass.is_a?(Class) ? klass : klass.to_s.camelize.constantize
+        end
       end
 
       module MyInstanceMethods
         def history_tracks
-          @history_tracks ||= Mongoid::History.tracker_class.where(
+          @history_tracks ||= self.class.tracker_class.where(
             scope: related_scope,
             association_chain: association_hash
           ).asc(:version)
@@ -290,7 +295,7 @@ module Mongoid
           if track_history_for_action?(action)
             current_version = (send(history_trackable_options[:version_field]) || 0) + 1
             send("#{history_trackable_options[:version_field]}=", current_version)
-            Mongoid::History.tracker_class.create!(history_tracker_attributes(action.to_sym).merge(version: current_version, action: action.to_s, trackable: self))
+            self.class.tracker_class.create!(history_tracker_attributes(action.to_sym).merge(version: current_version, action: action.to_s, trackable: self))
           end
           clear_trackable_memoization
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ $LOAD_PATH.push File.expand_path('../../lib', __FILE__)
 
 require 'active_support/all'
 require 'mongoid'
+require 'request_store' if ENV['REQUEST_STORE_VERSION']
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 

--- a/spec/unit/options_spec.rb
+++ b/spec/unit/options_spec.rb
@@ -44,6 +44,7 @@ describe Mongoid::History::Options do
     let(:expected_options) do
       { on: :all,
         except: [:created_at, :updated_at],
+        tracker_class_name: nil,
         modifier_field: :modifier,
         version_field: :version,
         changes_method: :changes,
@@ -60,6 +61,7 @@ describe Mongoid::History::Options do
       let(:expected_options) do
         { on: %w(fields),
           except: %w(created_at updated_at),
+          tracker_class_name: nil,
           modifier_field: :modifier,
           version_field: :version,
           changes_method: :changes,

--- a/spec/unit/store/default_store_spec.rb
+++ b/spec/unit/store/default_store_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'Default Store', if: ENV['REQUEST_STORE_VERSION'].blank? do
+  describe 'Mongoid::History' do
+    describe '.store' do
+      it 'should return Thread object' do
+        expect(Mongoid::History.store).to be_a Thread
+      end
+    end
+  end
+end

--- a/spec/unit/store/request_store_spec.rb
+++ b/spec/unit/store/request_store_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'RequestStore', if: ENV['REQUEST_STORE_VERSION'].present? do
+  describe 'Mongoid::History' do
+    describe '.store' do
+      it 'should return RequestStore' do
+        expect(Mongoid::History.store).to be_a Hash
+      end
+    end
+  end
+end

--- a/spec/unit/trackable_spec.rb
+++ b/spec/unit/trackable_spec.rb
@@ -36,6 +36,7 @@ describe Mongoid::History::Trackable do
     let(:expected_option) do
       { on: ['fields'],
         except: %w(created_at updated_at),
+        tracker_class_name: nil,
         modifier_field: :modifier,
         version_field: :version,
         changes_method: :changes,
@@ -284,6 +285,40 @@ describe Mongoid::History::Trackable do
         expect(m).to receive(:my_changes).once.and_call_original
         m.save
       end
+    end
+  end
+
+  describe '#tracker_class' do
+    before :all do
+      MyTrackerClass = Class.new
+    end
+
+    before { MyModel.instance_variable_set(:@history_trackable_options, nil) }
+
+    context 'when options contain tracker_class_name' do
+      context 'when underscored' do
+        before { MyModel.track_history tracker_class_name: 'my_tracker_class' }
+        it { expect(MyModel.tracker_class).to eq MyTrackerClass }
+      end
+
+      context 'when camelcased' do
+        before { MyModel.track_history tracker_class_name: 'MyTrackerClass' }
+        it { expect(MyModel.tracker_class).to eq MyTrackerClass }
+      end
+
+      context 'when constant' do
+        before { MyModel.track_history tracker_class_name: MyTrackerClass }
+        it { expect(MyModel.tracker_class).to eq MyTrackerClass }
+      end
+    end
+
+    context 'when options not contain tracker_class_name' do
+      before { MyModel.track_history }
+      it { expect(MyModel.tracker_class).to eq Tracker }
+    end
+
+    after :all do
+      Object.send(:remove_const, :MyTrackerClass)
     end
   end
 

--- a/spec/unit/tracker_spec.rb
+++ b/spec/unit/tracker_spec.rb
@@ -1,10 +1,19 @@
 require 'spec_helper'
 
 describe Mongoid::History::Tracker do
+  before do
+    @tracker_class_name = Mongoid::History.tracker_class_name
+    Mongoid::History.tracker_class_name = nil
+  end
+
   it 'should set tracker_class_name when included' do
     class MyTracker
       include Mongoid::History::Tracker
     end
     expect(Mongoid::History.tracker_class_name).to eq(:my_tracker)
+  end
+
+  after do
+    Mongoid::History.tracker_class_name = @tracker_class_name
   end
 end


### PR DESCRIPTION
- Added ability to customize tracker class for each trackable; multiple trackers across the app are now possible
- Added automatic support for `request_store` gem as drop-in replacement for `Thread.current`