### PR TITLE
Default hash fields to an empty hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------
 
 * Your contribution here.
+* [#166](https://github.com/aq1018/mongoid-history/pull/166): Hash fields should default to an empty Hash - [@johnnyshields](https://github.com/johnnyshields).
 * [#144](https://github.com/aq1018/mongoid-history/pull/158): Can modify history tracker insertion on object creation - [@sivagollapalli](https://github.com/sivagollapalli).
 * [#155](https://github.com/aq1018/mongoid-history/pull/155): Add support to whitelist the attributes for tracked embeds_one and embeds_many relations - [@JagdeepSingh](https://github.com/JagdeepSingh).
 * [#154](https://github.com/aq1018/mongoid-history/pull/154): Prevent soft-deleted embedded documents from tracking - [@JagdeepSingh](https://github.com/JagdeepSingh).

--- a/lib/mongoid/history/tracker.rb
+++ b/lib/mongoid/history/tracker.rb
@@ -9,8 +9,8 @@ module Mongoid
         attr_writer :trackable
 
         field :association_chain,       type: Array, default: []
-        field :modified,                type: Hash
-        field :original,                type: Hash
+        field :modified,                type: Hash, default: {}
+        field :original,                type: Hash, default: {}
         field :version,                 type: Integer
         field :action,                  type: String
         field :scope,                   type: String

--- a/spec/unit/tracker_spec.rb
+++ b/spec/unit/tracker_spec.rb
@@ -13,6 +13,15 @@ describe Mongoid::History::Tracker do
     expect(Mongoid::History.tracker_class_name).to eq(:my_tracker)
   end
 
+  it 'should set fields defaults' do
+    class MyTrackerTwo
+      include Mongoid::History::Tracker
+    end
+    expect(MyTrackerTwo.new.association_chain).to eq([])
+    expect(MyTrackerTwo.new.original).to eq({})
+    expect(MyTrackerTwo.new.modified).to eq({})
+  end
+
   describe '#tracked_edits' do
     before(:all) do
       TrackerOne = Class.new do


### PR DESCRIPTION
This is useful when you create a tracker class instance manually. Otherwise, you can get nil-errors when certain methods are called on the instance.